### PR TITLE
changed path for get_stream_url so label is applied with Playlist.Add

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -225,7 +225,7 @@ def __add_stations(stations, add_custom=False):
             'path': plugin.url_for(
                 'get_stream_url',
                 station_id=station_id,
-                station_name=station.get('name', ''),
+                station_name=station.get('name', '').encode('utf-8'),
             ),
             'is_playable': True,
         })


### PR DESCRIPTION
Hi there,

Awesome addon! works so well, only one little issue I had:
When you add a file path to the playlist with the jsonrpc to uses the last parameter in the url as the playlist item label.  So when a radio station is added, the label ends up being the id. 

eg `plugin://plugin.audio.radio_de/station/14971` label = `14971`

This patch adds an extra param to the path, the label, which gives the station a much more friendly name in the playlist.

eg `plugin://plugin.audio.radio_de/station/14971/SBS+PopAsia` label = `SBS PopAsia`

Didn't seem to break anything but I am definitely no python expert :)
