### PR TITLE
Fix radio.de API limitation of 100 rows

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -41,6 +41,8 @@ class RadioApi():
     USER_AGENT = 'XBMC Addon Radio'
 
     PLAYLIST_PREFIXES = ('m3u', 'pls', 'asx', 'xml')
+    
+    MAX_ROWS = 100
 
     def __init__(self, language='english', user_agent=USER_AGENT):
         self.set_language(language)
@@ -90,11 +92,26 @@ class RadioApi():
         if not category_type in self.get_category_types():
             raise ValueError('Bad category_type')
         path = 'menu/broadcastsofcategory'
-        param = {
-            'category': '_%s' % category_type,
-            'value': category_value,
-        }
-        stations = self.__api_call(path, param)
+        start = 0
+        fetched_all_stations = False
+        stations = []
+        while not fetched_all_stations:
+            param = {
+                'category': '_%s' % category_type,
+                'value': category_value,
+                'start': str(start),
+                'rows': str(RadioApi.MAX_ROWS),
+            }
+            fetched_stations = self.__api_call(path, param)
+            
+            if len(fetched_stations) == 0:
+                fetched_all_stations = True
+            else:
+                start += RadioApi.MAX_ROWS
+                stations += fetched_stations
+        
+        self.log("get_stations_by_category Fetched " + str(len(stations)) + " stations.")
+            
         return self.__format_stations(stations)
 
     def search_stations_by_string(self, search_string):

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -103,11 +103,12 @@ class RadioApi():
                 'rows': str(RadioApi.MAX_ROWS),
             }
             fetched_stations = self.__api_call(path, param)
+            num_fetched_stations = len(fetched_stations)
             
-            if len(fetched_stations) == 0:
+            if num_fetched_stations == 0:
                 fetched_all_stations = True
             else:
-                start += RadioApi.MAX_ROWS
+                start += num_fetched_stations
                 stations += fetched_stations
         
         self.log("get_stations_by_category Fetched " + str(len(stations)) + " stations.")


### PR DESCRIPTION
The radio.de API just returns 100 stations per request. This is not acceptable, especially for the country and language categories where thousands of stations are available.

With this MR, the `start` parameter is used to loop over all stations of a category. The performance is pretty poor, but at least every station of a category is available.